### PR TITLE
restored the sort-functionality

### DIFF
--- a/v5/ooapi.v5.core/Models/EducationSpecification.cs
+++ b/v5/ooapi.v5.core/Models/EducationSpecification.cs
@@ -101,7 +101,7 @@ namespace ooapi.v5.Models
 
         [JsonIgnore]
         [SortAllowed]
-        [SortDefault]
+        //[SortDefault]
         public List<Attribute> Attributes { get; set; }
 
 

--- a/v5/ooapi.v5.core/Repositories/BaseRepository.cs
+++ b/v5/ooapi.v5.core/Repositories/BaseRepository.cs
@@ -19,9 +19,9 @@ public class BaseRepository<T> where T : class
 
         var searchedSet = !String.IsNullOrWhiteSpace(dataRequestParameters.SearchTerm) ? OrderedQueryable.SearchBy<T>(set, dataRequestParameters.SearchTerm) : set;
         var filteredSet = (dataRequestParameters.Filters != null && dataRequestParameters.Filters.Count > 0) ? OrderedQueryable.FilterBy<T>(searchedSet, dataRequestParameters.Filters) : searchedSet;
-    //    var orderedSet = (dataRequestParameters.Sort != null) ? OrderedQueryable.OrderBy<T>(filteredSet, dataRequestParameters.Sort) : filteredSet;
+        var orderedSet = (dataRequestParameters.Sort != null) ? OrderedQueryable.OrderBy<T>(filteredSet, dataRequestParameters.Sort) : filteredSet;
 
-        return new Pagination<T>(filteredSet, dataRequestParameters ?? new DataRequestParameters());
+        return new Pagination<T>(orderedSet, dataRequestParameters ?? new DataRequestParameters());
 
     }
 


### PR DESCRIPTION
restored the sort-functionality, but commented the sortdefault attribute at EducationSpecification (the fallback sorting), since the sorting doesn't work with fields from the Attributes table. If sorting doesn't work, try commenting the sortdefault attribute in the model you're trying to request.