### PR TITLE
Fix swagger documentation return types for collections

### DIFF
--- a/v5/ooapi.v5/Controllers/AcademicSessionsController.cs
+++ b/v5/ooapi.v5/Controllers/AcademicSessionsController.cs
@@ -52,7 +52,7 @@ public class AcademicSessionsController : BaseController
     [Route("academic-sessions")]
     [ValidateModelState]
     [SwaggerOperation("AcademicSessionsGet")]
-    [SwaggerResponse(statusCode: 200, type: typeof(AcademicSessions), description: "OK")]
+    [SwaggerResponse(statusCode: 200, type: typeof(Pagination<AcademicSession>), description: "OK")]
     public virtual IActionResult AcademicSessionsGet([FromQuery] PrimaryCodeParam primaryCodeParam, [FromQuery] FilterParams filterParams, [FromQuery] PagingParams pagingParams, [FromQuery] string? academicSessionType, [FromQuery] Guid? parent, [FromQuery] Guid? year, [FromQuery] string? sort = "startDate")
     {
         Pagination<AcademicSession> result = null;
@@ -118,7 +118,7 @@ public class AcademicSessionsController : BaseController
     [Route("academic-sessions/{academicSessionId}/offerings")]
     [ValidateModelState]
     [SwaggerOperation("AcademicSessionsAcademicSessionIdOfferingsGet")]
-    [SwaggerResponse(statusCode: 200, type: typeof(Offerings), description: "OK")]
+    [SwaggerResponse(statusCode: 200, type: typeof(Pagination<Offering>), description: "OK")]
     public virtual IActionResult AcademicSessionsAcademicSessionIdOfferingsGet([FromRoute][Required] Guid academicSessionId, [FromQuery] FilterParams filterParams, [FromQuery] PagingParams pagingParams, [FromQuery] string? teachingLanguage, [FromQuery] string? offeringType, [FromQuery] bool? resultExpected, [FromQuery] DateTime? since, [FromQuery] DateTime? until, [FromQuery] string? sort = "startDate")
     {
         return BadRequest(new ErrorResponse(400, "Not implemented yet."));

--- a/v5/ooapi.v5/Controllers/BuildingsController.cs
+++ b/v5/ooapi.v5/Controllers/BuildingsController.cs
@@ -97,7 +97,7 @@ public class BuildingsController : BaseController
     [Route("buildings/{buildingId}/rooms")]
     [ValidateModelState]
     [SwaggerOperation("BuildingsBuildingIdRoomsGet")]
-    [SwaggerResponse(statusCode: 200, type: typeof(Rooms), description: "OK")]
+    [SwaggerResponse(statusCode: 200, type: typeof(Pagination<Room>), description: "OK")]
     public virtual IActionResult BuildingsBuildingIdRoomsGet([FromRoute][Required] Guid buildingId, [FromQuery] FilterParams filterParams, [FromQuery] PagingParams pagingParams, [FromQuery] string? roomType, [FromQuery] string? sort = "name")
     {
         DataRequestParameters parameters = new DataRequestParameters(filterParams, pagingParams, sort);
@@ -127,7 +127,7 @@ public class BuildingsController : BaseController
     [Route("buildings")]
     [ValidateModelState]
     [SwaggerOperation("BuildingsGet")]
-    [SwaggerResponse(statusCode: 200, type: typeof(Buildings), description: "OK")]
+    [SwaggerResponse(statusCode: 200, type: typeof(Pagination<Building>), description: "OK")]
     public virtual IActionResult BuildingsGet([FromQuery] PrimaryCodeParam primaryCodeParam, [FromQuery] FilterParams filterParams, [FromQuery] PagingParams pagingParams, [FromQuery] string? sort = "name")
     {
         DataRequestParameters parameters = new DataRequestParameters(primaryCodeParam, filterParams, pagingParams, sort);

--- a/v5/ooapi.v5/Controllers/ComponentsController.cs
+++ b/v5/ooapi.v5/Controllers/ComponentsController.cs
@@ -68,7 +68,7 @@ public class ComponentsController : BaseController
     [Route("components/{componentId}/offerings")]
     [ValidateModelState]
     [SwaggerOperation("ComponentsComponentIdOfferingsGet")]
-    [SwaggerResponse(statusCode: 200, type: typeof(ComponentOfferings), description: "OK")]
+    [SwaggerResponse(statusCode: 200, type: typeof(Pagination<ComponentOffering>), description: "OK")]
     public virtual IActionResult ComponentsComponentIdOfferingsGet([FromRoute][Required] Guid componentId, [FromQuery] FilterParams filterParams, [FromQuery] PagingParams pagingParams, [FromQuery] string? teachingLanguage, [FromQuery] bool? resultExpected, [FromQuery] DateTime? since, [FromQuery] DateTime? until, [FromQuery] string? sort = "startDateTime")
     {
         return BadRequest(new ErrorResponse(400, "Not implemented yet."));

--- a/v5/ooapi.v5/Controllers/CoursesController.cs
+++ b/v5/ooapi.v5/Controllers/CoursesController.cs
@@ -45,7 +45,7 @@ public class CoursesController : BaseController
     [Route("courses/{courseId}/components")]
     [ValidateModelState]
     [SwaggerOperation("CoursesCourseIdComponentsGet")]
-    [SwaggerResponse(statusCode: 200, type: typeof(Components), description: "OK")]
+    [SwaggerResponse(statusCode: 200, type: typeof(Pagination<Component>), description: "OK")]
     public virtual IActionResult CoursesCourseIdComponentsGet([FromRoute][Required] Guid courseId, [FromQuery] FilterParams filterParams, [FromQuery] PagingParams pagingParams, [FromQuery] string? teachingLanguage, [FromQuery] string? componentType, [FromQuery] string? sort = "componentId")
     {
         DataRequestParameters parameters = new DataRequestParameters(filterParams, pagingParams, sort);
@@ -104,7 +104,7 @@ public class CoursesController : BaseController
     [Route("courses/{courseId}/offerings")]
     [ValidateModelState]
     [SwaggerOperation("CoursesCourseIdOfferingsGet")]
-    [SwaggerResponse(statusCode: 200, type: typeof(CourseOfferings), description: "OK")]
+    [SwaggerResponse(statusCode: 200, type: typeof(Pagination<CourseOffering>), description: "OK")]
     public virtual IActionResult CoursesCourseIdOfferingsGet([FromRoute][Required] Guid courseId, [FromQuery] FilterParams filterParams, [FromQuery] PagingParams pagingParams, [FromQuery] string? teachingLanguage, [FromQuery] List<string>? modeOfDelivery, [FromQuery] bool? resultExpected, [FromQuery] DateTime? since, [FromQuery] DateTime? until, [FromQuery] string? sort = "startDate")
     {
         return BadRequest(new ErrorResponse(400, "Not implemented yet."));
@@ -131,7 +131,7 @@ public class CoursesController : BaseController
     [ValidateModelState]
     [SwaggerOperation("CoursesGet")]
     //[SwaggerResponse(statusCode: 200, type: typeof(MyPagination<Course>), description: "OK")]
-    [SwaggerResponse(statusCode: 200, type: typeof(Courses), description: "OK")]
+    [SwaggerResponse(statusCode: 200, type: typeof(Pagination<Course>), description: "OK")]
     public virtual IActionResult CoursesGet([FromQuery] PrimaryCodeParam primaryCodeParam, [FromQuery] FilterParams filterParams, [FromQuery] PagingParams pagingParams, [FromQuery] string? teachingLanguage, [FromQuery] string? level, [FromQuery] List<string>? modeOfDelivery, [FromQuery] string? sort = "name")
     {
         DataRequestParameters parameters = new DataRequestParameters(primaryCodeParam, filterParams, pagingParams, sort);

--- a/v5/ooapi.v5/Controllers/EducationSpecificationsController.cs
+++ b/v5/ooapi.v5/Controllers/EducationSpecificationsController.cs
@@ -46,7 +46,7 @@ public class EducationSpecificationsController : BaseController
     [Route("education-specifications/{educationSpecificationId}/courses")]
     [ValidateModelState]
     [SwaggerOperation("EducationSpecificationsEducationSpecificationIdCoursesGet")]
-    [SwaggerResponse(statusCode: 200, type: typeof(Courses), description: "OK")]
+    [SwaggerResponse(statusCode: 200, type: typeof(Pagination<Course>), description: "OK")]
     public virtual IActionResult EducationSpecificationsEducationSpecificationIdCoursesGet([FromRoute][Required] Guid educationSpecificationId, [FromQuery] FilterParams filterParams, [FromQuery] PagingParams pagingParams, [FromQuery] string? teachingLanguage, [FromQuery] string? level, [FromQuery] List<string>? modeOfDelivery, [FromQuery] string? sort = "courseId")
     {
         DataRequestParameters parameters = new DataRequestParameters(filterParams, pagingParams, sort);
@@ -89,7 +89,7 @@ public class EducationSpecificationsController : BaseController
     [Route("education-specifications/{educationSpecificationId}/education-specifications")]
     [ValidateModelState]
     [SwaggerOperation("EducationSpecificationsEducationSpecificationIdEducationSpecificationsGet")]
-    [SwaggerResponse(statusCode: 200, type: typeof(EducationSpecifications), description: "OK")]
+    [SwaggerResponse(statusCode: 200, type: typeof(Pagination<EducationSpecification>), description: "OK")]
     public virtual IActionResult EducationSpecificationsEducationSpecificationIdEducationSpecificationsGet([FromRoute][Required] Guid educationSpecificationId, [FromQuery] FilterParams filterParams, [FromQuery] PagingParams pagingParams, [FromQuery] string? sort = "educationSpecificationId")
     {
         DataRequestParameters parameters = new DataRequestParameters(filterParams, pagingParams, sort);
@@ -152,7 +152,7 @@ public class EducationSpecificationsController : BaseController
     [Route("education-specifications/{educationSpecificationId}/programs")]
     [ValidateModelState]
     [SwaggerOperation("EducationSpecificationsEducationSpecificationIdProgramsGet")]
-    [SwaggerResponse(statusCode: 200, type: typeof(Programs), description: "OK")]
+    [SwaggerResponse(statusCode: 200, type: typeof(Pagination<Models.Program>), description: "OK")]
     public virtual IActionResult EducationSpecificationsEducationSpecificationIdProgramsGet([FromRoute][Required] Guid educationSpecificationId, [FromQuery] FilterParams filterParams, [FromQuery] PagingParams pagingParams, [FromQuery] string? teachingLanguage, [FromQuery] string? programType, [FromQuery] string? qualificationAwarded, [FromQuery] string? levelOfQualification, [FromQuery] string? sector, [FromQuery] string? fieldsOfStudy, [FromQuery] string? crohoCreboCode, [FromQuery] string? sort = "name")
     {
         DataRequestParameters parameters = new DataRequestParameters(filterParams, pagingParams, sort);
@@ -211,7 +211,7 @@ public class EducationSpecificationsController : BaseController
     [Route("education-specifications")]
     [ValidateModelState]
     [SwaggerOperation("EducationSpecificationsGet")]
-    [SwaggerResponse(statusCode: 200, type: typeof(EducationSpecifications), description: "OK")]
+    [SwaggerResponse(statusCode: 200, type: typeof(Pagination<EducationSpecification>), description: "OK")]
     public virtual IActionResult EducationSpecificationsGet([FromQuery] PrimaryCodeParam primaryCodeParam, [FromQuery] FilterParams filterParams, [FromQuery] PagingParams pagingParams, [FromQuery] string? educationSpecificationType = "", [FromQuery] string? sort = "name")
     {
         DataRequestParameters parameters = new DataRequestParameters(filterParams, pagingParams, sort);

--- a/v5/ooapi.v5/Controllers/GroupsController.cs
+++ b/v5/ooapi.v5/Controllers/GroupsController.cs
@@ -43,7 +43,7 @@ public class GroupsController : BaseController
     [Route("groups")]
     [ValidateModelState]
     [SwaggerOperation("GroupsGet")]
-    [SwaggerResponse(statusCode: 200, type: typeof(Groups), description: "OK")]
+    [SwaggerResponse(statusCode: 200, type: typeof(Pagination<Group>), description: "OK")]
     public virtual IActionResult GroupsGet([FromQuery] PrimaryCodeParam primaryCodeParam, [FromQuery] FilterParams filterParams, [FromQuery] PagingParams pagingParams, [FromQuery] string? groupType, [FromQuery] string? sort = "name")
     {
         DataRequestParameters parameters = new DataRequestParameters(primaryCodeParam, filterParams, pagingParams, sort);
@@ -97,7 +97,7 @@ public class GroupsController : BaseController
     [Route("groups/{groupId}/persons")]
     [ValidateModelState]
     [SwaggerOperation("GroupsGroupIdPersonsGet")]
-    [SwaggerResponse(statusCode: 200, type: typeof(Persons), description: "OK")]
+    [SwaggerResponse(statusCode: 200, type: typeof(Pagination<Person>), description: "OK")]
     public virtual IActionResult GroupsGroupIdPersonsGet([FromRoute][Required] Guid groupId, [FromQuery] FilterParams filterParams, [FromQuery] PagingParams pagingParams, [FromQuery] List<string>? affiliations, [FromQuery] string? sort = "personId")
     {
         DataRequestParameters parameters = new DataRequestParameters(filterParams, pagingParams, sort);

--- a/v5/ooapi.v5/Controllers/NewsController.cs
+++ b/v5/ooapi.v5/Controllers/NewsController.cs
@@ -43,7 +43,7 @@ public class NewsController : BaseController
     [Route("news-feeds")]
     [ValidateModelState]
     [SwaggerOperation("NewsFeedsGet")]
-    [SwaggerResponse(statusCode: 200, type: typeof(NewsFeeds), description: "OK")]
+    [SwaggerResponse(statusCode: 200, type: typeof(Pagination<NewsFeed>), description: "OK")]
     public virtual IActionResult NewsFeedsGet([FromQuery] FilterParams filterParams, [FromQuery] PagingParams pagingParams, [FromQuery] string? newsFeedType, [FromQuery] string? sort = "name")
     {
         DataRequestParameters parameters = new DataRequestParameters(null, filterParams, pagingParams, sort);
@@ -96,7 +96,7 @@ public class NewsController : BaseController
     [Route("news-feeds/{newsFeedId}/news-items")]
     [ValidateModelState]
     [SwaggerOperation("NewsFeedsNewsFeedIdNewsItemsGet")]
-    [SwaggerResponse(statusCode: 200, type: typeof(NewsItems), description: "OK")]
+    [SwaggerResponse(statusCode: 200, type: typeof(Pagination<NewsItem>), description: "OK")]
     public virtual IActionResult NewsFeedsNewsFeedIdNewsItemsGet([FromRoute][Required] Guid newsFeedId, [FromQuery] FilterParams filterParams, [FromQuery] PagingParams pagingParams, [FromQuery] string? author, [FromQuery] string? sort = "newsItemId")
     {
         DataRequestParameters parameters = new DataRequestParameters(filterParams, pagingParams, sort);

--- a/v5/ooapi.v5/Controllers/OfferingsController.cs
+++ b/v5/ooapi.v5/Controllers/OfferingsController.cs
@@ -46,7 +46,7 @@ public class OfferingsController : BaseController
     [Route("offerings/{offeringId}/associations")]
     [ValidateModelState]
     [SwaggerOperation("OfferingsOfferingIdAssociationsGet")]
-    [SwaggerResponse(statusCode: 200, type: typeof(Associations), description: "OK")]
+    [SwaggerResponse(statusCode: 200, type: typeof(Pagination<Association>), description: "OK")]
     public virtual IActionResult OfferingsOfferingIdAssociationsGet([FromRoute][Required] Guid offeringId, [FromQuery] FilterParams filterParams, [FromQuery] PagingParams pagingParams, [FromQuery] string? associationType, [FromQuery] string? role, [FromQuery] string? state, [FromQuery] string? resultState, [FromQuery] string? sort = "associationId")
     {
         return BadRequest(new ErrorResponse(400, "Not implemented yet."));
@@ -107,7 +107,7 @@ public class OfferingsController : BaseController
     [Route("offerings/{offeringId}/groups")]
     [ValidateModelState]
     [SwaggerOperation("OfferingsOfferingIdGroupsGet")]
-    [SwaggerResponse(statusCode: 200, type: typeof(Groups), description: "OK")]
+    [SwaggerResponse(statusCode: 200, type: typeof(Pagination<Group>), description: "OK")]
     public virtual IActionResult OfferingsOfferingIdGroupsGet([FromRoute][Required] Guid offeringId, [FromQuery] FilterParams filterParams, [FromQuery] PagingParams pagingParams, [FromQuery] string? groupType, [FromQuery] string? sort = "name")
     {
         return BadRequest(new ErrorResponse(400,"Not implemented yet."));

--- a/v5/ooapi.v5/Controllers/OrganizationsController.cs
+++ b/v5/ooapi.v5/Controllers/OrganizationsController.cs
@@ -44,7 +44,7 @@ public class OrganizationsController : BaseController
     [Route("organizations")]
     [ValidateModelState]
     [SwaggerOperation("OrganizationsGet")]
-    [SwaggerResponse(statusCode: 200, type: typeof(Organizations), description: "OK")]
+    [SwaggerResponse(statusCode: 200, type: typeof(Pagination<Organization>), description: "OK")]
     public virtual IActionResult OrganizationsGet([FromQuery] PrimaryCodeParam primaryCodeParam, [FromQuery] FilterParams filterParams, [FromQuery] PagingParams pagingParams, [FromQuery] OrganizationTypeEnum? organizationType, [FromQuery] string? sort = "name")
     {
         DataRequestParameters parameters = new DataRequestParameters(filterParams, pagingParams, sort);
@@ -84,7 +84,7 @@ public class OrganizationsController : BaseController
     [Route("organizations/{organizationId}/components")]
     [ValidateModelState]
     [SwaggerOperation("OrganizationsOrganizationIdComponentsGet")]
-    [SwaggerResponse(statusCode: 200, type: typeof(Components), description: "OK")]
+    [SwaggerResponse(statusCode: 200, type: typeof(Pagination<Component>), description: "OK")]
     public virtual IActionResult OrganizationsOrganizationIdComponentsGet([FromRoute][Required] Guid organizationId, [FromQuery] FilterParams filterParams, [FromQuery] PagingParams pagingParams, [FromQuery] string? teachingLanguage, [FromQuery] string? componentType, [FromQuery] string? sort = "name")
     {
         DataRequestParameters parameters = new DataRequestParameters(filterParams, pagingParams, sort);
@@ -117,7 +117,7 @@ public class OrganizationsController : BaseController
     [Route("organizations/{organizationId}/courses")]
     [ValidateModelState]
     [SwaggerOperation("OrganizationsOrganizationIdCoursesGet")]
-    [SwaggerResponse(statusCode: 200, type: typeof(Courses), description: "OK")]
+    [SwaggerResponse(statusCode: 200, type: typeof(Pagination<Course>), description: "OK")]
     public virtual IActionResult OrganizationsOrganizationIdCoursesGet([FromRoute][Required] Guid organizationId, [FromQuery] FilterParams filterParams, [FromQuery] PagingParams pagingParams, [FromQuery] string? teachingLanguage, [FromQuery] string? level, [FromQuery] List<string>? modeOfDelivery, [FromQuery] string? sort = "name")
     {
         DataRequestParameters parameters = new DataRequestParameters(filterParams, pagingParams, sort);
@@ -148,7 +148,7 @@ public class OrganizationsController : BaseController
     [Route("organizations/{organizationId}/education-specifications")]
     [ValidateModelState]
     [SwaggerOperation("OrganizationsOrganizationIdEducationSpecificationsGet")]
-    [SwaggerResponse(statusCode: 200, type: typeof(EducationSpecifications), description: "OK")]
+    [SwaggerResponse(statusCode: 200, type: typeof(Pagination<EducationSpecification>), description: "OK")]
     public virtual IActionResult OrganizationsOrganizationIdEducationSpecificationsGet([FromRoute][Required] Guid organizationId, [FromQuery] FilterParams filterParams, [FromQuery] PagingParams pagingParams, [FromQuery] string? educationSpecificationType, [FromQuery] string? sort = "name")
     {
         DataRequestParameters parameters = new DataRequestParameters(filterParams, pagingParams, sort);
@@ -204,7 +204,7 @@ public class OrganizationsController : BaseController
     [Route("organizations/{organizationId}/groups")]
     [ValidateModelState]
     [SwaggerOperation("OrganizationsOrganizationIdGroupsGet")]
-    [SwaggerResponse(statusCode: 200, type: typeof(Groups), description: "OK")]
+    [SwaggerResponse(statusCode: 200, type: typeof(Pagination<Group>), description: "OK")]
     public virtual IActionResult OrganizationsOrganizationIdGroupsGet([FromRoute][Required] Guid organizationId, [FromQuery] FilterParams filterParams, [FromQuery] PagingParams pagingParams, [FromQuery] string? groupType, [FromQuery] string? sort = "name")
     {
         DataRequestParameters parameters = new DataRequestParameters(filterParams, pagingParams, sort);
@@ -239,7 +239,7 @@ public class OrganizationsController : BaseController
     [Route("organizations/{organizationId}/offerings")]
     [ValidateModelState]
     [SwaggerOperation("OrganizationsOrganizationIdOfferingsGet")]
-    [SwaggerResponse(statusCode: 200, type: typeof(Offerings), description: "OK")]
+    [SwaggerResponse(statusCode: 200, type: typeof(Pagination<Offering>), description: "OK")]
     public virtual IActionResult OrganizationsOrganizationIdOfferingsGet([FromRoute][Required] Guid organizationId, [FromQuery] FilterParams filterParams, [FromQuery] PagingParams pagingParams, [FromQuery] string? teachingLanguage, [FromQuery] string? offeringType, [FromQuery] bool? resultExpected, [FromQuery] DateTime? since, [FromQuery] DateTime? until, [FromQuery] string? sort = "startDate")
     {
         return BadRequest(new ErrorResponse(400, "Not implemented yet."));
@@ -268,7 +268,7 @@ public class OrganizationsController : BaseController
     [Route("organizations/{organizationId}/programs")]
     [ValidateModelState]
     [SwaggerOperation("OrganizationsOrganizationIdProgramsGet")]
-    [SwaggerResponse(statusCode: 200, type: typeof(Programs), description: "OK")]
+    [SwaggerResponse(statusCode: 200, type: typeof(Pagination<Models.Program>), description: "OK")]
     public virtual IActionResult OrganizationsOrganizationIdProgramsGet([FromRoute][Required] Guid organizationId, [FromQuery] FilterParams filterParams, [FromQuery] PagingParams pagingParams, [FromQuery] string? teachingLanguage, [FromQuery] string? programType, [FromQuery] string? qualificationAwarded, [FromQuery] string? levelOfQualification, [FromQuery] string? sector, [FromQuery] string? fieldsOfStudy, [FromQuery] string? sort = "name")
     {
         DataRequestParameters parameters = new DataRequestParameters(filterParams, pagingParams, sort);

--- a/v5/ooapi.v5/Controllers/PersonsController.cs
+++ b/v5/ooapi.v5/Controllers/PersonsController.cs
@@ -45,7 +45,7 @@ public class PersonsController : BaseController
     [Route("persons")]
     [ValidateModelState]
     [SwaggerOperation("PersonsGet")]
-    [SwaggerResponse(statusCode: 200, type: typeof(Persons), description: "OK")]
+    [SwaggerResponse(statusCode: 200, type: typeof(Pagination<Person>), description: "OK")]
     public virtual IActionResult PersonsGet([FromQuery] PrimaryCodeParam primaryCodeParam, [FromQuery] FilterParams filterParams, [FromQuery] PagingParams pagingParams, [FromQuery] List<string>? affiliations, [FromQuery] string? sort = "personId")
     {
         DataRequestParameters parameters = new DataRequestParameters(primaryCodeParam, filterParams, pagingParams, sort);
@@ -95,7 +95,7 @@ public class PersonsController : BaseController
     [Route("persons/{personId}/associations")]
     [ValidateModelState]
     [SwaggerOperation("PersonsPersonIdAssociationsGet")]
-    [SwaggerResponse(statusCode: 200, type: typeof(Associations), description: "OK")]
+    [SwaggerResponse(statusCode: 200, type: typeof(Pagination<Association>), description: "OK")]
     public virtual IActionResult PersonsPersonIdAssociationsGet([FromRoute][Required] Guid personId, [FromQuery] FilterParams filterParams, [FromQuery] PagingParams pagingParams, [FromQuery] string? associationType, [FromQuery] string? role, [FromQuery] string? state, [FromQuery] string? resultState, [FromQuery] string? sort = "associationId")
     {
         DataRequestParameters parameters = new DataRequestParameters(filterParams, pagingParams, sort);
@@ -148,7 +148,7 @@ public class PersonsController : BaseController
     [Route("persons/{personId}/groups")]
     [ValidateModelState]
     [SwaggerOperation("PersonsPersonIdGroupsGet")]
-    [SwaggerResponse(statusCode: 200, type: typeof(Groups), description: "OK")]
+    [SwaggerResponse(statusCode: 200, type: typeof(Pagination<Group>), description: "OK")]
     public virtual IActionResult PersonsPersonIdGroupsGet([FromRoute][Required] Guid personId, [FromQuery] FilterParams filterParams, [FromQuery] PagingParams pagingParams, [FromQuery] string? groupType, [FromQuery] string? sort = "name")
     {
         DataRequestParameters parameters = new DataRequestParameters(filterParams, pagingParams, sort);

--- a/v5/ooapi.v5/Controllers/ProgramsController.cs
+++ b/v5/ooapi.v5/Controllers/ProgramsController.cs
@@ -48,7 +48,7 @@ namespace ooapi.v5.Controllers
         [Route("programs")]
         [ValidateModelState]
         [SwaggerOperation("ProgramsGet")]
-        [SwaggerResponse(statusCode: 200, type: typeof(Programs), description: "OK")]
+        [SwaggerResponse(statusCode: 200, type: typeof(Pagination<Models.Program>), description: "OK")]
         public virtual IActionResult ProgramsGet([FromQuery] PrimaryCodeParam primaryCodeParam, [FromQuery] FilterParams filterParams, [FromQuery] PagingParams pagingParams, [FromQuery] string? teachingLanguage, [FromQuery] string? programType, [FromQuery] string? qualificationAwarded, [FromQuery] string? levelOfQualification, [FromQuery] string? sector, [FromQuery] string? fieldsOfStudy, [FromQuery] string? sort = "name")
         {
             DataRequestParameters parameters = new DataRequestParameters(primaryCodeParam, filterParams, pagingParams, sort);
@@ -81,7 +81,7 @@ namespace ooapi.v5.Controllers
         [Route("programs/{programId}/courses")]
         [ValidateModelState]
         [SwaggerOperation("ProgramsProgramIdCoursesGet")]
-        [SwaggerResponse(statusCode: 200, type: typeof(Courses), description: "OK")]
+        [SwaggerResponse(statusCode: 200, type: typeof(Pagination<Course>), description: "OK")]
         public virtual IActionResult ProgramsProgramIdCoursesGet([FromRoute][Required] Guid programId, [FromQuery] FilterParams filterParams, [FromQuery] PagingParams pagingParams, [FromQuery] string? teachingLanguage, [FromQuery] string? level, [FromQuery] List<string>? modeOfDelivery, [FromQuery] string? sort = "courseId")
         {
             DataRequestParameters parameters = new DataRequestParameters(filterParams, pagingParams, sort);
@@ -142,7 +142,7 @@ namespace ooapi.v5.Controllers
         [Route("programs/{programId}/offerings")]
         [ValidateModelState]
         [SwaggerOperation("ProgramsProgramIdOfferingsGet")]
-        [SwaggerResponse(statusCode: 200, type: typeof(ProgramOfferings), description: "OK")]
+        [SwaggerResponse(statusCode: 200, type: typeof(Pagination<ProgramOffering>), description: "OK")]
         public virtual IActionResult ProgramsProgramIdOfferingsGet([FromRoute][Required] Guid programId, [FromQuery] FilterParams filterParams, [FromQuery] PagingParams pagingParams, [FromQuery] string? teachingLanguage, [FromQuery] string? modeOfStudy, [FromQuery] bool? resultExpected, [FromQuery] DateTime? since, [FromQuery] DateTime? until, [FromQuery] string? sort = "startDate")
         {
             DataRequestParameters parameters = new DataRequestParameters(filterParams, pagingParams, sort);
@@ -179,7 +179,7 @@ namespace ooapi.v5.Controllers
         [Route("programs/{programId}/programs")]
         [ValidateModelState]
         [SwaggerOperation("ProgramsProgramIdProgramsGet")]
-        [SwaggerResponse(statusCode: 200, type: typeof(Programs), description: "OK")]
+        [SwaggerResponse(statusCode: 200, type: typeof(Pagination<Models.Program>), description: "OK")]
         public virtual IActionResult ProgramsProgramIdProgramsGet([FromRoute][Required] Guid programId, [FromQuery] FilterParams filterParams, [FromQuery] PagingParams pagingParams, [FromQuery] string? teachingLanguage, [FromQuery] string? programType, [FromQuery] string? qualificationAwarded, [FromQuery] string? levelOfQualification, [FromQuery] string? sector, [FromQuery] string? fieldsOfStudy, [FromQuery] string? sort = "name")
         {
             DataRequestParameters parameters = new DataRequestParameters(filterParams, pagingParams, sort);

--- a/v5/ooapi.v5/Controllers/RoomsController.cs
+++ b/v5/ooapi.v5/Controllers/RoomsController.cs
@@ -42,7 +42,7 @@ public class RoomsController : BaseController
     [Route("rooms")]
     [ValidateModelState]
     [SwaggerOperation("RoomsGet")]
-    [SwaggerResponse(statusCode: 200, type: typeof(Rooms), description: "OK")]
+    [SwaggerResponse(statusCode: 200, type: typeof(Pagination<Room>), description: "OK")]
     public virtual IActionResult RoomsGet([FromQuery] PrimaryCodeParam primaryCodeParam, [FromQuery] FilterParams filterParams, [FromQuery] PagingParams pagingParams, [FromQuery] string? roomType, [FromQuery] string? sort = "name")
     {
         DataRequestParameters parameters = new DataRequestParameters(primaryCodeParam, filterParams, pagingParams, sort);

--- a/v5/ooapi.v5/Startup.cs
+++ b/v5/ooapi.v5/Startup.cs
@@ -7,14 +7,20 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
+
 using Newtonsoft.Json.Serialization;
+
 using ooapi.v5.core.Repositories;
+using ooapi.v5.Models;
 using ooapi.v5.Security;
+
 using Swashbuckle.AspNetCore.SwaggerGen;
+
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Xml.XPath;
 
 namespace ooapi.v5
@@ -111,7 +117,17 @@ namespace ooapi.v5
 
             services.ConfigureSwaggerGen(options =>
             {
-                options.CustomSchemaIds(x => x.Name);
+                options.CustomSchemaIds(type =>
+                {
+                    // Generate unique type name for generic Pagination<T> 
+                    if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Pagination<>))
+                    {
+                        Type genericArgument = type.GetGenericArguments()[0];
+                        return $"Pagination_{genericArgument.Name}";
+                    }
+                    return type.Name;
+                });
+
             });
         }
 


### PR DESCRIPTION
The [documentation](https://openonderwijsapi.nl/specification/v5/docs.html#tag/education-specifications/paths/~1education-specifications/get) describes that each collection is returned in a pagination object. This was not represented in the swagger documentation, which just showed a list of the object. 

This was fixed in each controller and additional code was added to Startup.cs to prevent Swagger from creating duplicate type names. 